### PR TITLE
Generate cookie policy pages with CSS frameworks

### DIFF
--- a/cookies-examples/antd/cookies.php
+++ b/cookies-examples/antd/cookies.php
@@ -1,0 +1,42 @@
+<?php
+// Ant Design - using Ant Design CSS (for static HTML approximation)
+?><!doctype html>
+<html lang="ro">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Politica de Cookies • Ant Design</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/antd@5.21.2/dist/reset.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/antd@5.21.2/dist/antd.min.css" />
+  <style> body { padding: 24px; } </style>
+</head>
+<body>
+  <div class="ant-typography">
+    <h1 class="ant-typography">Politica de Cookies</h1>
+    <div class="ant-typography" style="color:#888">Ultima actualizare: <?php echo date('Y-m-d'); ?></div>
+  </div>
+
+  <div class="ant-card ant-card-bordered" style="max-width: 900px; margin-top: 16px;">
+    <div class="ant-card-body">
+      <h2 class="ant-typography">Ce sunt cookie-urile?</h2>
+      <p>Fișiere text mici stocate pe dispozitiv pentru a reține informații utile.</p>
+
+      <h3 class="ant-typography">Tipuri</h3>
+      <ul>
+        <li>Necesare</li>
+        <li>Analitice</li>
+        <li>Funcționale</li>
+        <li>Marketing</li>
+      </ul>
+
+      <h3 class="ant-typography">Gestionare</h3>
+      <p>Puteți ajusta preferințele din browser.</p>
+      <div class="ant-space" style="gap: 8px">
+        <a class="ant-btn ant-btn-primary" href="#accept"><span class="ant-btn-icon"></span><span>Accept toate</span></a>
+        <a class="ant-btn" href="#preferinte"><span>Preferințe</span></a>
+        <a class="ant-btn ant-btn-default" href="#respinge"><span>Respinge neesențiale</span></a>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/cookies-examples/bootstrap5/cookies.php
+++ b/cookies-examples/bootstrap5/cookies.php
@@ -1,0 +1,46 @@
+<?php
+// Bootstrap 5 - using CDN
+?><!doctype html>
+<html lang="ro">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Politica de Cookies • Bootstrap 5</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+</head>
+<body class="bg-light">
+  <nav class="navbar bg-white border-bottom">
+    <div class="container">
+      <span class="navbar-brand mb-0 h1">Politica de Cookies</span>
+      <small class="text-muted">Ultima actualizare: <?php echo date('Y-m-d'); ?></small>
+    </div>
+  </nav>
+
+  <main class="container py-4">
+    <div class="card shadow-sm">
+      <div class="card-body">
+        <h2 class="card-title">Ce sunt cookie-urile?</h2>
+        <p class="card-text">Fișiere text stocate pe dispozitiv pentru funcționalități și analiză.</p>
+
+        <h3>Tipuri</h3>
+        <ul>
+          <li>Necesare</li>
+          <li>Analitice</li>
+          <li>Funcționale</li>
+          <li>Marketing</li>
+        </ul>
+
+        <h3>Gestionare</h3>
+        <p>Puteți controla preferințele în browser.</p>
+        <div class="d-flex gap-2">
+          <a class="btn btn-primary" href="#accept">Accept toate</a>
+          <a class="btn btn-outline-secondary" href="#preferinte">Preferințe</a>
+          <a class="btn btn-light" href="#respinge">Respinge neesențiale</a>
+        </div>
+      </div>
+    </div>
+  </main>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+</body>
+</html>

--- a/cookies-examples/bulma/cookies.php
+++ b/cookies-examples/bulma/cookies.php
@@ -1,0 +1,50 @@
+<?php
+// Bulma Cookie Policy Page
+?><!doctype html>
+<html lang="ro">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Politica de Cookies • Bulma</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css" integrity="sha256-fS3lr7fA9k9iQpZ1nMskl0k3S3t3XNK7ZJ3Qei5E1a8=" crossorigin="anonymous">
+</head>
+<body>
+  <section class="hero is-primary">
+    <div class="hero-body">
+      <p class="title">Politica de Cookies</p>
+      <p class="subtitle">Ultima actualizare: <?php echo date('Y-m-d'); ?></p>
+    </div>
+  </section>
+
+  <section class="section">
+    <div class="container">
+      <div class="content">
+        <h2>Ce sunt cookie-urile?</h2>
+        <p>Cookie-urile sunt fișiere text stocate pe dispozitiv pentru a îmbunătăți experiența de navigare.</p>
+
+        <h2>Tipuri de cookie-uri</h2>
+        <ul>
+          <li><strong>Necesare:</strong> asigură funcții de bază.</li>
+          <li><strong>Analitice:</strong> ne ajută să înțelegem utilizarea site-ului.</li>
+          <li><strong>Funcționale:</strong> salvează preferințe.</li>
+          <li><strong>Marketing:</strong> publicitate personalizată.</li>
+        </ul>
+
+        <h2>Cum folosim cookie-urile</h2>
+        <p>Le utilizăm pentru autentificare, analize și personalizare.</p>
+
+        <h2>Gestionare</h2>
+        <p>Puteți configura browserul să accepte sau să respingă cookie-uri. Dezactivarea anumitor cookie-uri poate afecta funcționalitatea.</p>
+        <div class="buttons">
+          <a class="button is-success" href="#accept">Accept toate</a>
+          <a class="button is-link" href="#preferinte">Preferințe</a>
+          <a class="button is-danger is-light" href="#respinge">Respinge neesențiale</a>
+        </div>
+
+        <h2>Contact</h2>
+        <p>Scrieți-ne la <a href="mailto:privacy@example.com">privacy@example.com</a>.</p>
+      </div>
+    </div>
+  </section>
+</body>
+</html>

--- a/cookies-examples/daisyui/cookies.php
+++ b/cookies-examples/daisyui/cookies.php
@@ -1,0 +1,46 @@
+<?php
+// DaisyUI 4 (Tailwind-based) Cookie Policy Page
+?><!doctype html>
+<html lang="ro" data-theme="light">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Politica de Cookies • DaisyUI 4</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://cdn.jsdelivr.net/npm/daisyui@4.12.10/dist/full.min.css" rel="stylesheet" type="text/css" />
+</head>
+<body class="bg-base-200">
+  <div class="navbar bg-base-100 shadow-sm">
+    <div class="container mx-auto px-4">
+      <a class="btn btn-ghost normal-case text-xl">Politica de Cookies</a>
+      <span class="ml-auto opacity-70 text-sm">Ultima actualizare: <?php echo date('Y-m-d'); ?></span>
+    </div>
+  </div>
+
+  <main class="container mx-auto px-4 py-8">
+    <div class="card bg-base-100 shadow-md">
+      <div class="card-body space-y-4">
+        <h2 class="card-title">Ce sunt cookie-urile?</h2>
+        <p>Cookie-urile sunt fișiere text care ajută la furnizarea de funcționalități și analiză.</p>
+
+        <h3 class="text-lg font-semibold">Tipuri de cookie-uri</h3>
+        <ul class="list-disc list-inside">
+          <li>Necesare</li>
+          <li>Analitice</li>
+          <li>Funcționale</li>
+          <li>Marketing</li>
+        </ul>
+
+        <h3 class="text-lg font-semibold">Gestionare</h3>
+        <p>Puteți configura preferințele direct din browser.</p>
+
+        <div class="card-actions justify-end">
+          <a class="btn btn-primary" href="#accept">Accept toate</a>
+          <a class="btn" href="#preferinte">Preferințe</a>
+          <a class="btn btn-ghost" href="#respinge">Respinge neesențiale</a>
+        </div>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/cookies-examples/flowbite/cookies.php
+++ b/cookies-examples/flowbite/cookies.php
@@ -1,0 +1,56 @@
+<?php
+// Flowbite (Tailwind-based) Cookie Policy Page
+?><!doctype html>
+<html lang="ro">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Politica de Cookies • Flowbite</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.5.1/flowbite.min.css" rel="stylesheet" />
+</head>
+<body class="bg-gray-50 text-gray-900">
+  <header class="bg-white border-b">
+    <div class="max-w-4xl mx-auto px-4 py-6">
+      <h1 class="text-2xl font-semibold">Politica de Cookies</h1>
+      <p class="text-sm text-gray-500">Ultima actualizare: <?php echo date('Y-m-d'); ?></p>
+    </div>
+  </header>
+
+  <main class="max-w-4xl mx-auto px-4 py-8">
+    <article class="bg-white rounded-lg shadow-sm p-6 space-y-6">
+      <section>
+        <h2 class="text-xl font-semibold mb-2">Ce sunt cookie-urile?</h2>
+        <p class="text-gray-700">Cookie-urile sunt fișiere text mici plasate pe dispozitivul dvs. pentru a reține informații. Folosite pentru îmbunătățirea experienței și analiză.</p>
+      </section>
+
+      <section>
+        <h2 class="text-xl font-semibold mb-2">Tipuri de cookie-uri</h2>
+        <ul class="list-disc list-inside text-gray-700 space-y-1">
+          <li>Necesare</li>
+          <li>Analitice</li>
+          <li>Funcționale</li>
+          <li>Marketing</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2 class="text-xl font-semibold mb-2">Gestionare</h2>
+        <p class="text-gray-700">Puteți controla cookie-urile din setările browserului.</p>
+        <div class="flex gap-3 mt-3">
+          <a class="inline-flex items-center justify-center px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded hover:bg-blue-700" href="#accept">Accept toate</a>
+          <a class="inline-flex items-center justify-center px-4 py-2 text-sm font-medium text-blue-700 bg-blue-50 rounded hover:bg-blue-100" href="#preferinte">Preferințe</a>
+          <a class="inline-flex items-center justify-center px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded hover:bg-gray-200" href="#respinge">Respinge neesențiale</a>
+        </div>
+      </section>
+
+      <section>
+        <h2 class="text-xl font-semibold mb-2">Contact</h2>
+        <p class="text-gray-700">Ne puteți scrie la <a class="text-blue-600 hover:underline" href="mailto:privacy@example.com">privacy@example.com</a>.</p>
+      </section>
+    </article>
+  </main>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.5.1/flowbite.min.js"></script>
+</body>
+</html>

--- a/cookies-examples/foundation6/cookies.php
+++ b/cookies-examples/foundation6/cookies.php
@@ -1,0 +1,70 @@
+<?php
+// Foundation 6 Cookie Policy Page
+?><!doctype html>
+<html lang="ro">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Politica de Cookies • Foundation 6</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/foundation-sites@6.7.5/dist/css/foundation.min.css" integrity="sha256-fkzS4C5iL1dNhqXr8BJu7nco2vGg/vTp94agq+PiWfQ=" crossorigin="anonymous">
+  <style>
+    .cookie-section { margin-bottom: 2rem; }
+    .cookie-meta { color: #666; font-size: 0.9rem; }
+  </style>
+</head>
+<body>
+  <div class="top-bar">
+    <div class="top-bar-left">
+      <ul class="menu">
+        <li class="menu-text">Politica de Cookies</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="grid-container">
+    <div class="grid-x grid-margin-x">
+      <div class="cell large-10 large-offset-1">
+        <div class="callout primary">
+          <h1 class="h3">Politica privind modulele cookie</h1>
+          <p class="cookie-meta">Ultima actualizare: <?php echo date('Y-m-d'); ?></p>
+        </div>
+
+        <div class="cookie-section">
+          <h2 class="h4">Ce sunt cookie-urile?</h2>
+          <p>Cookie-urile sunt fișiere text mici stocate pe dispozitivul dvs. atunci când vizitați un site web. Ele ne ajută să oferim o experiență mai bună, să analizăm traficul și să personalizăm conținutul.</p>
+        </div>
+
+        <div class="cookie-section">
+          <h2 class="h4">Tipuri de cookie-uri</h2>
+          <ul>
+            <li>Necesare – esențiale pentru funcționarea site-ului.</li>
+            <li>Analitice – ne ajută să înțelegem modul de utilizare a site-ului.</li>
+            <li>Funcționale – rețin preferințele dvs.</li>
+            <li>Marketing – utilizate pentru publicitate personalizată.</li>
+          </ul>
+        </div>
+
+        <div class="cookie-section">
+          <h2 class="h4">Cum folosim cookie-urile</h2>
+          <p>Folosim cookie-uri pentru autentificare, reținerea preferințelor, măsurarea performanței și îmbunătățirea conținutului.</p>
+        </div>
+
+        <div class="cookie-section">
+          <h2 class="h4">Gestionarea cookie-urilor</h2>
+          <p>Puteți controla și/sau șterge cookie-urile din setările browserului. Rețineți că dezactivarea cookie-urilor esențiale poate afecta funcționarea site-ului.</p>
+          <div class="button-group">
+            <a class="button success" href="#accept">Accept toate</a>
+            <a class="button warning" href="#preferinte">Preferințe</a>
+            <a class="button alert" href="#respinge">Respinge neesențiale</a>
+          </div>
+        </div>
+
+        <div class="callout secondary">
+          <h2 class="h5">Contact</h2>
+          <p>Pentru întrebări, ne puteți scrie la <a href="mailto:privacy@example.com">privacy@example.com</a>.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/cookies-examples/mantine/cookies.php
+++ b/cookies-examples/mantine/cookies.php
@@ -1,0 +1,44 @@
+<?php
+// Mantine v7 - static CSS approximation via CDN
+?><!doctype html>
+<html lang="ro">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Politica de Cookies • Mantine v7</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mantine/core@7.12.2/styles.css" />
+  <style>
+    body { background: #f8f9fa; color: #212529; font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Inter, Helvetica, Arial, sans-serif; padding: 24px; }
+    .card { background: #fff; border: 1px solid #dee2e6; border-radius: 8px; box-shadow: 0 1px 2px rgba(0,0,0,.04); padding: 20px; max-width: 900px; }
+    .btn { display:inline-block; padding: 8px 12px; border-radius: 6px; text-decoration:none; }
+    .btn-primary { background:#228be6; color:#fff; }
+    .btn-light { background:#f1f3f5; color:#212529; }
+    .btn-outline { border:1px solid #dee2e6; color:#212529; }
+  </style>
+</head>
+<body>
+  <h1>Politica de Cookies</h1>
+  <div style="color:#868e96">Ultima actualizare: <?php echo date('Y-m-d'); ?></div>
+
+  <div class="card" style="margin-top:16px;">
+    <h2>Ce sunt cookie-urile?</h2>
+    <p>Fișiere text stocate pe dispozitiv pentru a reține informații utile.</p>
+
+    <h3>Tipuri</h3>
+    <ul>
+      <li>Necesare</li>
+      <li>Analitice</li>
+      <li>Funcționale</li>
+      <li>Marketing</li>
+    </ul>
+
+    <h3>Gestionare</h3>
+    <p>Preferințele pot fi setate în browser.</p>
+    <div style="display:flex; gap:8px; margin-top:8px;">
+      <a class="btn btn-primary" href="#accept">Accept toate</a>
+      <a class="btn btn-light" href="#preferinte">Preferințe</a>
+      <a class="btn btn-outline" href="#respinge">Respinge neesențiale</a>
+    </div>
+  </div>
+</body>
+</html>

--- a/cookies-examples/materialize/cookies.php
+++ b/cookies-examples/materialize/cookies.php
@@ -1,0 +1,48 @@
+<?php
+// Materialize CSS - using CDN
+?><!doctype html>
+<html lang="ro">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Politica de Cookies • Materialize</title>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+</head>
+<body class="grey lighten-5">
+  <nav class="white z-depth-0">
+    <div class="container">
+      <div class="nav-wrapper">
+        <a href="#" class="brand-logo black-text">Politica de Cookies</a>
+        <ul id="nav-mobile" class="right hide-on-med-and-down">
+          <li><span class="grey-text">Ultima actualizare: <?php echo date('Y-m-d'); ?></span></li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+
+  <main class="container" style="margin-top: 2rem;">
+    <div class="card">
+      <div class="card-content">
+        <span class="card-title">Ce sunt cookie-urile?</span>
+        <p>Fișiere text stocate pe dispozitiv pentru funcționalități și analiză.</p>
+        <h6 style="margin-top:1rem;">Tipuri</h6>
+        <ul class="browser-default">
+          <li>Necesare</li>
+          <li>Analitice</li>
+          <li>Funcționale</li>
+          <li>Marketing</li>
+        </ul>
+        <h6 style="margin-top:1rem;">Gestionare</h6>
+        <p>Puteți controla preferințele în browser.</p>
+      </div>
+      <div class="card-action">
+        <a class="btn deep-purple" href="#accept">Accept toate</a>
+        <a class="btn-flat" href="#preferinte">Preferințe</a>
+        <a class="btn grey lighten-4 black-text" href="#respinge">Respinge neesențiale</a>
+      </div>
+    </div>
+  </main>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+</body>
+</html>

--- a/cookies-examples/nextui2/cookies.php
+++ b/cookies-examples/nextui2/cookies.php
@@ -1,0 +1,42 @@
+<?php
+// NextUI 2 - static approximation using their CSS variables
+?><!doctype html>
+<html lang="ro">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Politica de Cookies • NextUI 2</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@nextui-org/theme@2.2.11/dist/nextui.min.css" />
+  <style>
+    body { background: var(--nextui-background); color: var(--nextui-foreground); font-family: Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; padding: 24px; }
+    .card { background: var(--nextui-content1); border-radius: 12px; border: 1px solid var(--nextui-divider); padding: 20px; max-width: 900px; box-shadow: 0 1px 2px rgba(0,0,0,.04); }
+    .btn { display:inline-block; padding: 8px 12px; border-radius: 8px; text-decoration:none; border:1px solid var(--nextui-divider); color: var(--nextui-foreground); }
+    .btn-primary { background: var(--nextui-primary); color: var(--nextui-primary-foreground); border-color: var(--nextui-primary); }
+  </style>
+</head>
+<body>
+  <h1>Politica de Cookies</h1>
+  <div style="opacity: .7;">Ultima actualizare: <?php echo date('Y-m-d'); ?></div>
+
+  <div class="card" style="margin-top:16px;">
+    <h2>Ce sunt cookie-urile?</h2>
+    <p>Fișiere text stocate pe dispozitiv pentru funcționalități și analiză.</p>
+
+    <h3>Tipuri</h3>
+    <ul>
+      <li>Necesare</li>
+      <li>Analitice</li>
+      <li>Funcționale</li>
+      <li>Marketing</li>
+    </ul>
+
+    <h3>Gestionare</h3>
+    <p>Preferințele pot fi setate în browser.</p>
+    <div style="display:flex; gap:8px; margin-top:8px;">
+      <a class="btn btn-primary" href="#accept">Accept toate</a>
+      <a class="btn" href="#preferinte">Preferințe</a>
+      <a class="btn" href="#respinge">Respinge neesențiale</a>
+    </div>
+  </div>
+</body>
+</html>

--- a/cookies-examples/open-props/cookies.php
+++ b/cookies-examples/open-props/cookies.php
@@ -1,0 +1,65 @@
+<?php
+// Open Props Cookie Policy Page
+?><!doctype html>
+<html lang="ro">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Politica de Cookies • Open Props</title>
+  <link rel="stylesheet" href="https://unpkg.com/open-props/normalize.min.css">
+  <link rel="stylesheet" href="https://unpkg.com/open-props/open-props.min.css">
+  <style>
+    :root {
+      --brand: var(--indigo-6);
+    }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif; background: var(--gray-1); color: var(--gray-12); }
+    header { background: white; border-bottom: 1px solid var(--gray-4); }
+    .container { max-width: 70ch; margin-inline: auto; padding-inline: var(--size-4); }
+    .prose { line-height: 1.7; }
+    .card { background: white; border: 1px solid var(--gray-4); border-radius: var(--radius-3); box-shadow: var(--shadow-2); padding: var(--size-5); }
+    .btn { display:inline-block; padding: var(--size-2) var(--size-3); border-radius: var(--radius-2); border: 1px solid var(--gray-5); text-decoration:none; }
+    .btn-primary { background: var(--brand); color: white; border-color: var(--brand); }
+    .btn-ghost { background: transparent; color: var(--gray-12); }
+    .stack { display: grid; gap: var(--size-4); }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="container" style="padding-block: var(--size-5)">
+      <h1 style="margin:0">Politica de Cookies</h1>
+      <p class="prose" style="margin:0; color: var(--gray-8)">Ultima actualizare: <?php echo date('Y-m-d'); ?></p>
+    </div>
+  </header>
+
+  <main class="container" style="padding-block: var(--size-7)">
+    <article class="card stack">
+      <section class="stack">
+        <h2>Ce sunt cookie-urile?</h2>
+        <p class="prose">Cookie-urile sunt fișiere text mici care ajută site-urile să funcționeze corect și eficient.</p>
+      </section>
+      <section class="stack">
+        <h2>Tipuri</h2>
+        <ul class="prose">
+          <li>Necesare</li>
+          <li>Analitice</li>
+          <li>Funcționale</li>
+          <li>Marketing</li>
+        </ul>
+      </section>
+      <section class="stack">
+        <h2>Gestionare</h2>
+        <p class="prose">Puteți controla cookie-urile din setările browserului dvs.</p>
+        <div class="stack" style="grid-auto-flow: column; justify-content: start;">
+          <a class="btn btn-primary" href="#accept">Accept toate</a>
+          <a class="btn" href="#preferinte">Preferințe</a>
+          <a class="btn btn-ghost" href="#respinge">Respinge neesențiale</a>
+        </div>
+      </section>
+      <section class="stack">
+        <h2>Contact</h2>
+        <p class="prose">Ne puteți scrie la <a href="mailto:privacy@example.com">privacy@example.com</a>.</p>
+      </section>
+    </article>
+  </main>
+</body>
+</html>

--- a/cookies-examples/panda/cookies.php
+++ b/cookies-examples/panda/cookies.php
@@ -1,0 +1,49 @@
+<?php
+// Panda CSS (preset of CSS-in-JS) - static approximation using CSS variables
+?><!doctype html>
+<html lang="ro">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Politica de Cookies • Panda CSS</title>
+  <style>
+    :root {
+      --bg: #0b1020;
+      --panel: #0f172a;
+      --text: #e2e8f0;
+      --muted: #94a3b8;
+      --primary: #7c3aed;
+    }
+    body { background: var(--bg); color: var(--text); font-family: Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; padding: 24px; }
+    .card { background: var(--panel); border: 1px solid #1e293b; border-radius: 12px; padding: 20px; max-width: 900px; box-shadow: 0 1px 2px rgba(0,0,0,.3); }
+    .muted { color: var(--muted); }
+    .btn { display:inline-block; padding: 8px 12px; border-radius: 8px; text-decoration:none; border:1px solid #334155; color: var(--text); }
+    .btn-primary { background: var(--primary); border-color: var(--primary); color: white; }
+  </style>
+</head>
+<body>
+  <h1>Politica de Cookies</h1>
+  <div class="muted">Ultima actualizare: <?php echo date('Y-m-d'); ?></div>
+
+  <div class="card" style="margin-top:16px;">
+    <h2>Ce sunt cookie-urile?</h2>
+    <p>Fișiere text care susțin funcționalități și analiză.</p>
+
+    <h3>Tipuri</h3>
+    <ul>
+      <li>Necesare</li>
+      <li>Analitice</li>
+      <li>Funcționale</li>
+      <li>Marketing</li>
+    </ul>
+
+    <h3>Gestionare</h3>
+    <p>Controlați preferințele în browser.</p>
+    <div style="display:flex; gap:8px; margin-top:8px;">
+      <a class="btn btn-primary" href="#accept">Accept toate</a>
+      <a class="btn" href="#preferinte">Preferințe</a>
+      <a class="btn" href="#respinge">Respinge neesențiale</a>
+    </div>
+  </div>
+</body>
+</html>

--- a/cookies-examples/pico/cookies.php
+++ b/cookies-examples/pico/cookies.php
@@ -1,0 +1,41 @@
+<?php
+// Pico.css - using CDN
+?><!doctype html>
+<html lang="ro">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Politica de Cookies • Pico.css</title>
+  <link rel="stylesheet" href="https://unpkg.com/@picocss/pico@2.0.6/css/pico.min.css">
+</head>
+<body>
+  <header class="container">
+    <h1>Politica de Cookies</h1>
+    <p><small>Ultima actualizare: <?php echo date('Y-m-d'); ?></small></p>
+  </header>
+
+  <main class="container">
+    <article>
+      <h2>Ce sunt cookie-urile?</h2>
+      <p>Fișiere text stocate pe dispozitiv pentru funcționalități și analiză.</p>
+
+      <h3>Tipuri</h3>
+      <ul>
+        <li>Necesare</li>
+        <li>Analitice</li>
+        <li>Funcționale</li>
+        <li>Marketing</li>
+      </ul>
+
+      <h3>Gestionare</h3>
+      <p>Puteți controla preferințele în browser.</p>
+
+      <footer>
+        <a role="button" class="contrast" href="#accept">Accept toate</a>
+        <a role="button" href="#preferinte">Preferințe</a>
+        <a role="button" class="secondary" href="#respinge">Respinge neesențiale</a>
+      </footer>
+    </article>
+  </main>
+</body>
+</html>

--- a/cookies-examples/radix/cookies.php
+++ b/cookies-examples/radix/cookies.php
@@ -1,0 +1,42 @@
+<?php
+// Radix UI primitives - use their colors and basic styles via CDN reset
+?><!doctype html>
+<html lang="ro">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Politica de Cookies • Radix UI</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@radix-ui/colors@3.0.0/sage.css" />
+  <style>
+    body { font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Inter, Helvetica, Arial, sans-serif; background: var(--sage-1); color: var(--sage-12); padding: 24px; }
+    .card { background: white; border: 1px solid var(--sage-6); border-radius: 8px; box-shadow: 0 1px 2px rgba(0,0,0,.05); padding: 20px; max-width: 900px; }
+    .btn { display:inline-block; padding: 8px 12px; border-radius: 6px; text-decoration:none; border:1px solid var(--sage-6); color: var(--sage-12); }
+    .btn-primary { background: var(--sage-12); color: white; border-color: var(--sage-12); }
+  </style>
+</head>
+<body>
+  <h1>Politica de Cookies</h1>
+  <div style="color: var(--sage-11)">Ultima actualizare: <?php echo date('Y-m-d'); ?></div>
+
+  <div class="card" style="margin-top:16px;">
+    <h2>Ce sunt cookie-urile?</h2>
+    <p>Fișiere text care ajută la funcționare și analiză.</p>
+
+    <h3>Tipuri</h3>
+    <ul>
+      <li>Necesare</li>
+      <li>Analitice</li>
+      <li>Funcționale</li>
+      <li>Marketing</li>
+    </ul>
+
+    <h3>Gestionare</h3>
+    <p>Puteți gestiona cookie-urile din browser.</p>
+    <div style="display:flex; gap:8px; margin-top:8px;">
+      <a class="btn btn-primary" href="#accept">Accept toate</a>
+      <a class="btn" href="#preferinte">Preferințe</a>
+      <a class="btn" href="#respinge">Respinge neesențiale</a>
+    </div>
+  </div>
+</body>
+</html>

--- a/cookies-examples/shadcn/cookies.php
+++ b/cookies-examples/shadcn/cookies.php
@@ -1,0 +1,46 @@
+<?php
+// shadcn/ui (Tailwind + Radix primitives) - static HTML approximation using Tailwind
+?><!doctype html>
+<html lang="ro">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Politica de Cookies • shadcn/ui</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-neutral-50 text-neutral-900">
+  <header class="border-b bg-white">
+    <div class="max-w-4xl mx-auto px-4 py-6">
+      <h1 class="text-2xl font-semibold tracking-tight">Politica de Cookies</h1>
+      <p class="text-sm text-neutral-500">Ultima actualizare: <?php echo date('Y-m-d'); ?></p>
+    </div>
+  </header>
+
+  <main class="max-w-4xl mx-auto px-4 py-8">
+    <article class="bg-white border rounded-lg p-6 shadow-sm space-y-6">
+      <section>
+        <h2 class="text-xl font-semibold">Ce sunt cookie-urile?</h2>
+        <p class="text-neutral-700">Fișiere text ce permit funcții, personalizare și analiză.</p>
+      </section>
+      <section>
+        <h3 class="text-lg font-medium">Tipuri</h3>
+        <ul class="list-disc list-inside text-neutral-700">
+          <li>Necesare</li>
+          <li>Analitice</li>
+          <li>Funcționale</li>
+          <li>Marketing</li>
+        </ul>
+      </section>
+      <section>
+        <h3 class="text-lg font-medium">Gestionare</h3>
+        <p class="text-neutral-700">Controlați preferințele din browser.</p>
+        <div class="flex gap-3">
+          <a class="inline-flex items-center justify-center rounded-md bg-black px-4 py-2 text-sm font-medium text-white hover:bg-black/90" href="#accept">Accept toate</a>
+          <a class="inline-flex items-center justify-center rounded-md bg-neutral-100 px-4 py-2 text-sm font-medium hover:bg-neutral-200" href="#preferinte">Preferințe</a>
+          <a class="inline-flex items-center justify-center rounded-md border px-4 py-2 text-sm font-medium hover:bg-neutral-50" href="#respinge">Respinge neesențiale</a>
+        </div>
+      </section>
+    </article>
+  </main>
+</body>
+</html>

--- a/cookies-examples/spectre/cookies.php
+++ b/cookies-examples/spectre/cookies.php
@@ -1,0 +1,52 @@
+<?php
+// Spectre.css - using CDN
+?><!doctype html>
+<html lang="ro">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Politica de Cookies • Spectre.css</title>
+  <link rel="stylesheet" href="https://unpkg.com/spectre.css/dist/spectre.min.css">
+  <link rel="stylesheet" href="https://unpkg.com/spectre.css/dist/spectre-exp.min.css">
+  <link rel="stylesheet" href="https://unpkg.com/spectre.css/dist/spectre-icons.min.css">
+</head>
+<body>
+  <header class="navbar">
+    <section class="navbar-section">
+      <a class="navbar-brand mr-2" href="#">Politica de Cookies</a>
+    </section>
+    <section class="navbar-section">
+      <span class="label">Ultima actualizare: <?php echo date('Y-m-d'); ?></span>
+    </section>
+  </header>
+
+  <main class="container grid-lg">
+    <div class="columns">
+      <div class="column col-8 col-mx-auto">
+        <div class="card">
+          <div class="card-header">
+            <div class="card-title h5">Ce sunt cookie-urile?</div>
+          </div>
+          <div class="card-body">
+            Fișiere text stocate pe dispozitiv pentru funcționalități și analiză.
+            <h6 class="mt-2">Tipuri</h6>
+            <ul>
+              <li>Necesare</li>
+              <li>Analitice</li>
+              <li>Funcționale</li>
+              <li>Marketing</li>
+            </ul>
+            <h6>Gestionare</h6>
+            <p>Puteți controla preferințele în browser.</p>
+          </div>
+          <div class="card-footer">
+            <a class="btn btn-primary" href="#accept">Accept toate</a>
+            <a class="btn" href="#preferinte">Preferințe</a>
+            <a class="btn btn-link" href="#respinge">Respinge neesențiale</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/cookies-examples/tailwind/cookies.php
+++ b/cookies-examples/tailwind/cookies.php
@@ -1,0 +1,46 @@
+<?php
+// Tailwind CSS - using CDN
+?><!doctype html>
+<html lang="ro">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Politica de Cookies • Tailwind CSS</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-50 text-gray-900">
+  <header class="bg-white border-b">
+    <div class="max-w-4xl mx-auto px-4 py-6">
+      <h1 class="text-2xl font-semibold">Politica de Cookies</h1>
+      <p class="text-sm text-gray-500">Ultima actualizare: <?php echo date('Y-m-d'); ?></p>
+    </div>
+  </header>
+
+  <main class="max-w-4xl mx-auto px-4 py-8">
+    <article class="bg-white rounded-lg shadow p-6 space-y-6">
+      <section>
+        <h2 class="text-xl font-semibold mb-2">Ce sunt cookie-urile?</h2>
+        <p>Fișiere text stocate pe dispozitiv, folosite pentru funcționalități și analiză.</p>
+      </section>
+      <section>
+        <h2 class="text-xl font-semibold mb-2">Tipuri</h2>
+        <ul class="list-disc list-inside space-y-1">
+          <li>Necesare</li>
+          <li>Analitice</li>
+          <li>Funcționale</li>
+          <li>Marketing</li>
+        </ul>
+      </section>
+      <section>
+        <h2 class="text-xl font-semibold mb-2">Gestionare</h2>
+        <p>Puteți seta preferințele în browser.</p>
+        <div class="flex gap-3 mt-3">
+          <a class="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded hover:bg-blue-700" href="#accept">Accept toate</a>
+          <a class="px-4 py-2 text-sm font-medium text-blue-700 bg-blue-50 rounded hover:bg-blue-100" href="#preferinte">Preferințe</a>
+          <a class="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded hover:bg-gray-200" href="#respinge">Respinge neesențiale</a>
+        </div>
+      </section>
+    </article>
+  </main>
+</body>
+</html>

--- a/cookies-examples/unocss/cookies.php
+++ b/cookies-examples/unocss/cookies.php
@@ -1,0 +1,50 @@
+<?php
+// UnoCSS Cookie Policy Page (using uno.min.css preflight and attributify runtime)
+?><!doctype html>
+<html lang="ro">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Politica de Cookies • UnoCSS</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@unocss/reset/tailwind.min.css">
+  <script src="https://cdn.jsdelivr.net/npm/@unocss/runtime"></script>
+  <style>
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif; }
+  </style>
+</head>
+<body class="bg-gray-50 text-gray-900">
+  <header class="bg-white border-b border-gray-200">
+    <div class="max-w-4xl mx-auto px-4 py-6">
+      <h1 class="text-2xl font-semibold">Politica de Cookies</h1>
+      <p class="text-sm text-gray-500">Ultima actualizare: <?php echo date('Y-m-d'); ?></p>
+    </div>
+  </header>
+
+  <main class="max-w-4xl mx-auto px-4 py-8">
+    <article class="bg-white rounded-lg shadow p-6 space-y-6">
+      <section>
+        <h2 class="text-xl font-semibold mb-2">Ce sunt cookie-urile?</h2>
+        <p>Fișiere text stocate pe dispozitiv care permit funcționalități și analiză.</p>
+      </section>
+      <section>
+        <h2 class="text-xl font-semibold mb-2">Tipuri de cookie-uri</h2>
+        <ul class="list-disc list-inside space-y-1">
+          <li>Necesare</li>
+          <li>Analitice</li>
+          <li>Funcționale</li>
+          <li>Marketing</li>
+        </ul>
+      </section>
+      <section>
+        <h2 class="text-xl font-semibold mb-2">Gestionare</h2>
+        <p>Puteți modifica preferințele din browser.</p>
+        <div class="flex gap-3 mt-3">
+          <a class="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded hover:bg-blue-700" href="#accept">Accept toate</a>
+          <a class="px-4 py-2 text-sm font-medium text-blue-700 bg-blue-50 rounded hover:bg-blue-100" href="#preferinte">Preferințe</a>
+          <a class="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded hover:bg-gray-200" href="#respinge">Respinge neesențiale</a>
+        </div>
+      </section>
+    </article>
+  </main>
+</body>
+</html>

--- a/cookies-examples/vanilla-extract-stitches/cookies.php
+++ b/cookies-examples/vanilla-extract-stitches/cookies.php
@@ -1,0 +1,46 @@
+<?php
+// Vanilla Extract / Stitches - static approximation using custom properties
+?><!doctype html>
+<html lang="ro">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Politica de Cookies • Vanilla Extract / Stitches</title>
+  <style>
+    :root { --bg:#fff; --text:#111; --muted:#666; --primary:#0ea5e9; --border:#e5e7eb; }
+    @media (prefers-color-scheme: dark) {
+      :root { --bg:#0b1020; --text:#e2e8f0; --muted:#94a3b8; --primary:#22d3ee; --border:#1f2937; }
+    }
+    body { background: var(--bg); color: var(--text); font-family: Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; padding: 24px; }
+    .card { background: var(--bg); border: 1px solid var(--border); border-radius: 12px; padding: 20px; max-width: 900px; box-shadow: 0 1px 2px rgba(0,0,0,.06); }
+    .muted { color: var(--muted); }
+    .btn { display:inline-block; padding: 8px 12px; border-radius: 8px; text-decoration:none; border:1px solid var(--border); color: var(--text); }
+    .btn-primary { background: var(--primary); border-color: var(--primary); color: white; }
+  </style>
+</head>
+<body>
+  <h1>Politica de Cookies</h1>
+  <div class="muted">Ultima actualizare: <?php echo date('Y-m-d'); ?></div>
+
+  <div class="card" style="margin-top:16px;">
+    <h2>Ce sunt cookie-urile?</h2>
+    <p>Fișiere text stocate pe dispozitiv pentru funcționalități și analiză.</p>
+
+    <h3>Tipuri</h3>
+    <ul>
+      <li>Necesare</li>
+      <li>Analitice</li>
+      <li>Funcționale</li>
+      <li>Marketing</li>
+    </ul>
+
+    <h3>Gestionare</h3>
+    <p>Preferințele pot fi setate în browser.</p>
+    <div style="display:flex; gap:8px; margin-top:8px;">
+      <a class="btn btn-primary" href="#accept">Accept toate</a>
+      <a class="btn" href="#preferinte">Preferințe</a>
+      <a class="btn" href="#respinge">Respinge neesențiale</a>
+    </div>
+  </div>
+</body>
+</html>

--- a/cookies-examples/windicss/cookies.php
+++ b/cookies-examples/windicss/cookies.php
@@ -1,0 +1,50 @@
+<?php
+// Windi CSS Cookie Policy Page (using CDN preset similar to Tailwind)
+?><!doctype html>
+<html lang="ro">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Politica de Cookies • Windi CSS</title>
+  <script src="https://cdn.jsdelivr.net/npm/windicss-runtime-dom@0.1.5/dist/index.iife.js"></script>
+  <style>
+    /* minimal fallback in case runtime fails */
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; background:#f8fafc; color:#0f172a; }
+  </style>
+</head>
+<body class="bg-slate-50 text-slate-900">
+  <header class="bg-white border-b border-slate-200">
+    <div class="max-w-4xl mx-auto px-4 py-6">
+      <h1 class="text-2xl font-semibold">Politica de Cookies</h1>
+      <p class="text-sm text-slate-500">Ultima actualizare: <?php echo date('Y-m-d'); ?></p>
+    </div>
+  </header>
+
+  <main class="max-w-4xl mx-auto px-4 py-8">
+    <article class="bg-white rounded-lg shadow p-6 space-y-6">
+      <section>
+        <h2 class="text-xl font-semibold mb-2">Ce sunt cookie-urile?</h2>
+        <p>Fișiere mici text care îmbunătățesc experiența de navigare și permit analiză.</p>
+      </section>
+      <section>
+        <h2 class="text-xl font-semibold mb-2">Tipuri de cookie-uri</h2>
+        <ul class="list-disc list-inside space-y-1">
+          <li>Necesare</li>
+          <li>Analitice</li>
+          <li>Funcționale</li>
+          <li>Marketing</li>
+        </ul>
+      </section>
+      <section>
+        <h2 class="text-xl font-semibold mb-2">Gestionare</h2>
+        <p>Puteți controla cookie-urile din setările browserului.</p>
+        <div class="flex gap-3 mt-3">
+          <a class="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded hover:bg-blue-700" href="#accept">Accept toate</a>
+          <a class="px-4 py-2 text-sm font-medium text-blue-700 bg-blue-50 rounded hover:bg-blue-100" href="#preferinte">Preferințe</a>
+          <a class="px-4 py-2 text-sm font-medium text-slate-700 bg-slate-100 rounded hover:bg-slate-200" href="#respinge">Respinge neesențiale</a>
+        </div>
+      </section>
+    </article>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
Add 19 `cookies.php` examples for various CSS frameworks.

---
<a href="https://cursor.com/background-agent?bcId=bc-9f6c0946-75cd-4a49-b273-07539aa42bb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9f6c0946-75cd-4a49-b273-07539aa42bb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

